### PR TITLE
Hide links in text by default, add --show-links option

### DIFF
--- a/reader/__main__.py
+++ b/reader/__main__.py
@@ -3,6 +3,8 @@
 Usage:
 ------
 
+    $ realpython [options] [<id>]
+
 List the latest tutorials:
 
     $ realpython
@@ -16,6 +18,12 @@ Read one tutorial:
 Read the latest tutorial:
 
     $ realpython 0
+
+
+Available options are:
+
+    -h, --help         Show this help
+    -l, --show-links   Show links in text
 
 
 Contact:
@@ -38,15 +46,22 @@ from reader import viewer
 
 def main() -> None:
     """Read the Real Python article feed"""
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    opts = [o for o in sys.argv[1:] if o.startswith("-")]
+
     # Show help message
-    if "-h" in sys.argv or "--help" in sys.argv:
+    if "-h" in opts or "--help" in opts:
         viewer.show(__doc__)
         return
 
+    # Should links be shown in the text
+    show_links = ("-l" in opts or "--show-links" in opts)
+
     # An article ID is given, show article
-    if len(sys.argv) > 1:
-        article = feed.get_article(sys.argv[1])
-        viewer.show(article)
+    if args:
+        for article_id in args:
+            article = feed.get_article(article_id, show_links)
+            viewer.show(article)
 
     # No ID is given, show list of articles
     else:

--- a/reader/feed.py
+++ b/reader/feed.py
@@ -24,7 +24,7 @@ def get_site() -> str:
     return f"{info.title} ({info.link})"
 
 
-def get_article(article_id: str) -> str:
+def get_article(article_id: str, links: bool = False) -> str:
     """Get article from feed with the given ID"""
     articles = _feed().entries
     try:
@@ -34,11 +34,17 @@ def get_article(article_id: str) -> str:
         msg = f"Unknown article ID, use ID from 0 to {max_id}"
         raise SystemExit(f"Error: {msg}")
 
+    # Get article as HTML
     try:
         html = article.content[0].value
     except AttributeError:
         html = article.summary
-    text = html2text.html2text(html)
+
+    # Convert HTML to plain text
+    to_text = html2text.HTML2Text()
+    to_text.ignore_links = not links
+    text = to_text.handle(html)
+
     return f"# {article.title}\n\n{text}"
 
 


### PR DESCRIPTION
Also adds possibility of showing several articles at once by listing their IDs on the command line