### PR TITLE
Upgrade to Python 3.7 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ For more information see the tutorial [How to Publish an Open-Source Python Pack
 
 You can install the Real Python Feed Reader from [PyPI](https://pypi.org/project/realpython-reader/):
 
-    pip install realpython-reader
+    python -m pip install realpython-reader
 
-The reader is supported on Python 2.7, as well as Python 3.4 and above.
+The reader is supported on Python 3.7 and above. Older versions of Python, including Python 2.7, is supported by version 1.0.0 of the reader.
 
 ## How to use
 
-The Real Python Feed Reader is a command line application, named `realpython`. To see a list of the [latest Real Python tutorials](https://realpython.com/) simply call the program:
+The Real Python Feed Reader is a command line application, named `realpython`. To see a list of the [latest Real Python tutorials](https://realpython.com/), call the program without any arguments:
 
     $ realpython
     The latest tutorials from Real Python (https://realpython.com/)
@@ -62,4 +62,3 @@ You can also call the Real Python Feed Reader in your own Python code, by import
     >>> from reader import feed
     >>> feed.get_titles()
     ['How to Publish an Open-Source Python Package to PyPI', ...]
-

--- a/reader/__init__.py
+++ b/reader/__init__.py
@@ -8,19 +8,15 @@ Import the `feed` module to work with the Real Python feed:
 
 See https://github.com/realpython/reader/ for more information
 """
-import importlib_resources as _resources
-
-try:
-    from configparser import ConfigParser as _ConfigParser
-except ImportError:  # Python 2
-    from ConfigParser import ConfigParser as _ConfigParser
-
+from configparser import ConfigParser
+from importlib import resources
 
 # Version of realpython-reader package
 __version__ = "1.0.0"
 
 # Read URL of feed from config file
-_cfg = _ConfigParser()
-with _resources.path("reader", "config.cfg") as _path:
-    _cfg.read(str(_path))
-URL = _cfg.get("feed", "url")
+cfg = ConfigParser()
+with resources.path("reader", "config.cfg") as path:
+    cfg.read(str(path))
+
+URL = cfg.get("feed", "url")

--- a/reader/__init__.py
+++ b/reader/__init__.py
@@ -9,6 +9,7 @@ Import the `feed` module to work with the Real Python feed:
 See https://github.com/realpython/reader/ for more information
 """
 import importlib_resources as _resources
+
 try:
     from configparser import ConfigParser as _ConfigParser
 except ImportError:  # Python 2

--- a/reader/__main__.py
+++ b/reader/__main__.py
@@ -47,8 +47,7 @@ import sys
 
 # Reader imports
 import reader
-from reader import feed
-from reader import viewer
+from reader import feed, viewer
 
 
 def main():  # type: () -> None

--- a/reader/__main__.py
+++ b/reader/__main__.py
@@ -50,7 +50,7 @@ import reader
 from reader import feed, viewer
 
 
-def main():  # type: () -> None
+def main() -> None:
     """Read the Real Python article feed"""
     args = [a for a in sys.argv[1:] if not a.startswith("-")]
     opts = [o for o in sys.argv[1:] if o.startswith("-")]
@@ -58,7 +58,7 @@ def main():  # type: () -> None
     # Show help message
     if "-h" in opts or "--help" in opts:
         viewer.show(__doc__)
-        return
+        raise SystemExit()
 
     # Should links be shown in the text
     show_links = "-l" in opts or "--show-links" in opts

--- a/reader/feed.py
+++ b/reader/feed.py
@@ -9,32 +9,31 @@ import html2text
 # Reader imports
 from reader import URL
 
-_CACHED_FEEDS = dict()  # type: Dict[str, feedparser.FeedParserDict]
+_CACHED_FEEDS: Dict[str, feedparser.FeedParserDict] = dict()
 
 
-def _feed(url=URL):  # type: (str) -> feedparser.FeedParserDict
+def _feed(url: str = URL) -> feedparser.FeedParserDict:
     """Cache contents of the feed, so it's only read once"""
     if url not in _CACHED_FEEDS:
         _CACHED_FEEDS[url] = feedparser.parse(url)
     return _CACHED_FEEDS[url]
 
 
-def get_site(url=URL):  # type: (str) -> str
+def get_site(url: str = URL) -> str:
     """Get name and link to web site of the feed"""
     info = _feed(url).feed
-    return u"{info.title} ({info.link})".format(info=info)
+    return f"{info.title} ({info.link})"
 
 
-def get_article(article_id, links=False, url=URL):
-    # type: (str, bool, str) -> str
+def get_article(article_id: str, links: bool = False, url: str = URL) -> str:
     """Get article from feed with the given ID"""
     articles = _feed(url).entries
     try:
         article = articles[int(article_id)]
     except (IndexError, ValueError):
         max_id = len(articles) - 1
-        msg = "Unknown article ID, use ID from 0 to {}".format(max_id)
-        raise SystemExit("Error: {}".format(msg))
+        msg = f"Unknown article ID, use ID from 0 to {max_id}"
+        raise SystemExit(f"Error: {msg}")
 
     # Get article as HTML
     try:
@@ -47,10 +46,10 @@ def get_article(article_id, links=False, url=URL):
     to_text.ignore_links = not links
     text = to_text.handle(html)
 
-    return u"# {}\n\n{}".format(article.title, text)
+    return f"# {article.title}\n\n{text}"
 
 
-def get_titles(url=URL):  # type: (str) -> List[str]
+def get_titles(url: str = URL) -> List[str]:
     """List titles in feed"""
     articles = _feed(url).entries
     return [a.title for a in articles]

--- a/reader/viewer.py
+++ b/reader/viewer.py
@@ -1,19 +1,16 @@
 """Functions for displaying the Real Python feed"""
 
-# Support Python 2
-from __future__ import print_function
-
 # Standard library imports
-from typing import List  # noqa
+from typing import List
 
 
-def show(article):  # type: (str) -> None
+def show(article: str) -> None:
     """Show one article"""
     print(article)
 
 
-def show_list(site, titles):  # type: (str, List[str]) -> None
+def show_list(site: str, titles: List[str]) -> None:
     """Show list of articles"""
-    print(u"The latest tutorials from {}".format(site))
+    print(f"The latest tutorials from {site}")
     for article_id, title in enumerate(titles):
-        print(u"{:>3} {}".format(article_id, title))
+        print(f"{article_id:>3} {title}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[mypy]
+strict = True
+
+[mypy-feedparser.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
 """Setup script for realpython-reader"""
 
-import os.path
+# Standard library imports
+import pathlib
+
+# Third party imports
 from setuptools import setup
 
 # The directory containing this file
-HERE = os.path.abspath(os.path.dirname(__file__))
+HERE = pathlib.Path(__file__).resolve().parent
 
-# The text of the README file
-with open(os.path.join(HERE, "README.md")) as fid:
-    README = fid.read()
+# The text of the README file is used as a description
+README = (HERE / "README.md").read_text()
 
 # This call to setup() does all the work
 setup(
@@ -24,13 +26,10 @@ setup(
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
     ],
     packages=["reader"],
     include_package_data=True,
-    install_requires=[
-        "feedparser", "html2text", "importlib_resources", "typing"
-    ],
+    install_requires=["feedparser", "html2text"],
     entry_points={"console_scripts": ["realpython=reader.__main__:main"]},
 )

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,6 +1,6 @@
 """Tests for the reader.feed module"""
 # Standard library imports
-import os.path
+import pathlib
 
 # Third party imports
 import pytest
@@ -9,19 +9,19 @@ import pytest
 from reader import feed
 
 # Current directory
-HERE = os.path.dirname(__file__)
+HERE = pathlib.Path(__file__).resolve().parent
 
 
 @pytest.fixture
 def local_feed():
     """Use local file instead of downloading feed from web"""
-    return os.path.join(HERE, "realpython_20180919.xml")
+    return HERE / "realpython_20180919.xml"
 
 
 @pytest.fixture
 def local_summary_feed():
     """Use local file instead of downloading feed from web"""
-    return os.path.join(HERE, "realpython_descriptions_20180919.xml")
+    return HERE / "realpython_descriptions_20180919.xml"
 
 
 #

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,8 +1,5 @@
 """Tests for the reader.viewer module"""
 
-# Third party imports
-import pytest
-
 # Reader imports
 from reader import viewer
 


### PR DESCRIPTION
Update the code to be more "modern". In particular:

- Use type hints instead of type comments (Python 3.6+)
- Use f-strings instead of `.format()` (Python 3.6+)
- Use `importlib.resources` (Python 3.7+)
