### PR TITLE
Remove setup.py as the shim is no longer needed for editable installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
The shim was needed until PEP 660 was implemented in Pip.